### PR TITLE
feat: add HTTP transport to Clinical Trials MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ COPY mcp_server.py .
 COPY manifest.json .
 COPY package.json .
 
+EXPOSE 8081
+ENV TRANSPORT=http
+
 CMD ["python", "mcp_server.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-fastmcp>=2.0.0
+mcp>=1.0.0
+uvicorn>=0.30.0
+starlette>=0.27.0
 requests>=2.31.0
 pydantic>=2.0.0
 typing-extensions>=4.0.0

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,9 +1,7 @@
 startCommand:
-  type: stdio
+  type: container
+  path: .
   configSchema:
     type: object
     description: No configuration required for Clinical Trials MCP Server
-  commandFunction: |-
-    (config) => ({ command: 'python', args: ['mcp_server.py'] })
   exampleConfig: {}
-  


### PR DESCRIPTION
## Summary
- enable HTTP transport with uvicorn and CORS middleware
- expose port 8081 and configure container start
- update dependencies and smithery config for container deployment

## Testing
- `python -m py_compile mcp_server.py`
- `pip install -r requirements.txt`
- `TRANSPORT=http PORT=8081 python mcp_server.py` (startup)


------
https://chatgpt.com/codex/tasks/task_e_68b25ed99b5883248acc55a9adfbb769