### PR TITLE
Remove Python dependencies from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ An MCP (Model Context Protocol) server that provides structured access to Clinic
 
 ## Installation
 
-1. Install dependencies:
+1. Install dependencies (Python runtime is required):
 ```bash
 pip install -r requirements.txt
 ```
+
+> **Note:** JavaScript package managers like `npm`, `pnpm`, or `bun` are not required for this project because all runtime dependencies are Python packages managed through `requirements.txt`.
 
 2. Run the MCP server:
 ```bash

--- a/package.json
+++ b/package.json
@@ -53,12 +53,7 @@
       "get_field_statistics"
     ]
   },
-  "dependencies": {
-    "mcp": ">=1.0.0",
-    "requests": ">=2.31.0",
-    "pydantic": ">=2.0.0",
-    "typing-extensions": ">=4.0.0"
-  },
+  "dependencies": {},
   "files": [
     "mcp_server.py",
     "requirements.txt",


### PR DESCRIPTION
## Summary
- remove Python packages from the package.json dependencies block to avoid bun install failures during deployment
- document that all runtime dependencies are managed through requirements.txt instead of JavaScript package managers

## Testing
- python -m pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68e26990be5c832493dfde67dfd35c79