### PR TITLE
Add Cloudflare Worker proxy for FastMCP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ pip install -r requirements.txt
 python mcp_server.py
 ```
 
+## Proxying the MCP server through Cloudflare Workers
+
+If you deploy the bundled Cloudflare Worker (in `src/index.ts`) you can serve the MCP
+manifest directly from the Worker while proxying live tool traffic—including the
+`/sse` streaming endpoint—to a FastMCP backend. To enable this:
+
+1. **Run the FastMCP backend** somewhere reachable from Cloudflare. The provided
+   Docker image starts the server in HTTP/SSE mode on port `8081`.
+2. **Expose the backend URL to the Worker** by setting the `FASTMCP_BASE_URL`
+   environment variable (or `FASTMCP_URL`/`BACKEND_URL`) in `wrangler.toml` or in
+   the Cloudflare dashboard. The value should be the base URL of your FastMCP
+   deployment, for example `https://fastmcp.example.com`.
+3. **Deploy the Worker**. Requests to `/manifest.json` and `/health` are served by
+   the Worker, while every other path is forwarded to the backend with streaming
+   preserved so `/sse` no longer returns a 404 or times out.
+
 ## Available Tools
 
 ### Search Tools


### PR DESCRIPTION
## Summary
- update the Cloudflare Worker to forward all MCP traffic to a configurable FastMCP backend while keeping health and manifest responses local
- add CORS handling and upstream error messaging so browsers can connect to the streaming /sse endpoint through the Worker
- document how to configure the Worker with the backend URL when deploying on Cloudflare

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e28ce9d1dc832490303e8cb0152b33